### PR TITLE
fix error while starting SASL client

### DIFF
--- a/impala/_thrift_api.py
+++ b/impala/_thrift_api.py
@@ -152,7 +152,7 @@ def get_transport(socket, host, kerberos_service_name, auth_mechanism='NOSASL',
 
         def sasl_factory():
             sasl_client = sasl.Client()
-            sasl_client.setAttr('host', host)
+            sasl_client.setAttr('host', 'hadoop')
             sasl_client.setAttr('service', kerberos_service_name)
             if auth_mechanism.upper() in ['PLAIN', 'LDAP']:
                 sasl_client.setAttr('username', user)


### PR DESCRIPTION
While connecting, error like this was raised:

TTransportException: TTransportException(type=1, message="Could not start SASL: b'Error in sasl_client_start (-1) SASL(-1): generic failure: GSSAPI Error: Unspecified GSS failure.  Minor code may provide more information (Server krbtgt/XX@XXYYZZ.HADOOP not found in Kerberos database)'")

This was caused by a sasl_client parameter setting error. And the fix works well for me. 

The original issue was like this: #262